### PR TITLE
Match literal type and enable compiletime anywhere

### DIFF
--- a/dist/transformer.js
+++ b/dist/transformer.js
@@ -42,10 +42,10 @@ function runTransformer(program) {
                         transpiledJs = transpiledJs.substr(0, transpiledJs.length - 1);
                     }
                     var result = eval("(" + transpiledJs + ")()");
-                    if (utils.isVariableDeclaration(node.parent) || utils.isExportAssignment(node.parent)) {
-                        return ts.createStringLiteral(result);
+                    if (typeof result === "object" || typeof result === "function" || result == null) {
+                        throw new Error("compiletime only supports primitive, non-null values");
                     }
-                    return ts.createStringLiteral(""); // TODO: delete node (return undefined not working)
+                    return ts.createLiteral(result);
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Transformer for Warcraft III maps using TypeScript.",
   "main": "dist/transformer.js",
   "scripts": {
+    "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "TriggerHappy",

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -51,11 +51,11 @@ export default function runTransformer(program: ts.Program): ts.TransformerFacto
 
           const result = eval(`(${transpiledJs})()`);
 
-          if (utils.isVariableDeclaration(node.parent) || utils.isExportAssignment(node.parent)) {
-            return ts.createStringLiteral(result);
+          if (typeof result === "object" || typeof result === "function" || result == null) {
+            throw new Error(`compiletime only supports primitive, non-null values`)
           }
 
-          return ts.createStringLiteral(""); // TODO: delete node (return undefined not working)
+          return ts.createLiteral(result);
         }
       }
     } else if (utils.isImportDeclaration(node)) {


### PR DESCRIPTION
- Swaps `createStringLiteral` with `createLiteral`. This gets us free type matching with numbers and booleans. Other values will throw errors (`null`, `undefined`, objects, arrays, functions, etc). The first two are likely user errors and the latter require a bit of work to support.
- Removes the checking of the node parent, allowing `compiletime` to be used anywhere (such as an argument for a function).
- Adds `build` to npm scripts.