### PR TITLE
Allow compiletime to figure out the return type automatically

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -21,8 +21,12 @@ declare interface CompiletimeContext {
 
 declare type CompiletimeReturnType = object | string | number | boolean | undefined | null | void;
 
-declare type CompiletimeFunction = (ctx: CompiletimeContext) => CompiletimeReturnType;
 /**
- * @param fn Expression to be evaluated by Node.
+ * Define a function that will be run on compile time in Node environment.
+ * It will also return any value that the function defined return
+ *
+ * @returns string | number | boolean | object | undefined | null
+ * @note Any other return type is considered never
  */
-declare function compiletime(fn: CompiletimeFunction): CompiletimeReturnType;
+declare function compiletime<T>(func: T): T extends (ctx: CompiletimeContext) => infer T ? (T extends () => any ? never : (T extends CompiletimeResult ? T : never)) : never;
+

--- a/types.d.ts
+++ b/types.d.ts
@@ -19,7 +19,7 @@ declare interface CompiletimeContext {
   constants: ConstantsType;
 }
 
-declare type CompiletimeReturnType = object | string | number | boolean | undefined | null | void;
+declare type CompiletimeReturnType = object | string | number | boolean | undefined | null;
 
 /**
  * Define a function that will be run on compile time in Node environment.


### PR DESCRIPTION
I wrote this long ago but too lazy to do anything about it
 I only have recently revisit my all of my old project that i coded in different language and found this piece of magic